### PR TITLE
Faster sql query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ dmypy.json
 .pyre/
 
 .DS_Store
+.vscode/settings.json

--- a/analysisdatalink/__init__.py
+++ b/analysisdatalink/__init__.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+from .utils import fix_wkb_column
 
 __version__ = "0.4.0"
 

--- a/analysisdatalink/datalink.py
+++ b/analysisdatalink/datalink.py
@@ -13,7 +13,7 @@ class AnalysisDataLink(datalink_base.AnalysisDataLinkBase):
 
     def specific_query(self, tables, filter_in_dict={}, filter_notin_dict={},
                        filter_equal_dict = {},
-                       select_columns=None, return_sql=False,
+                       select_columns=None, return_sql=False, n_threads=None,
                        fix_wkb=True, fix_decimal=True, import_via_buffer=False):
         """ Allows a more narrow query without requiring knowledge about the
             underlying data structures
@@ -69,7 +69,7 @@ class AnalysisDataLink(datalink_base.AnalysisDataLinkBase):
 
         return self._query(query_args=query_args, filter_args=filter_args,
                            join_args=join_args, select_columns=select_columns,
-                           fix_wkb=fix_wkb, fix_decimal=fix_decimal, return_sql=return_sql,
-                           import_via_buffer=import_via_buffer)
+                           fix_wkb=fix_wkb, fix_decimal=fix_decimal, n_threads=n_threads,
+                           return_sql=return_sql, import_via_buffer=import_via_buffer)
 
 

--- a/analysisdatalink/datalink.py
+++ b/analysisdatalink/datalink.py
@@ -13,7 +13,8 @@ class AnalysisDataLink(datalink_base.AnalysisDataLinkBase):
 
     def specific_query(self, tables, filter_in_dict={}, filter_notin_dict={},
                        filter_equal_dict = {},
-                       select_columns=None):
+                       select_columns=None, return_sql=False,
+                       fix_wkb=True, fix_decimal=True, import_via_buffer=False):
         """ Allows a more narrow query without requiring knowledge about the
             underlying data structures
 
@@ -67,6 +68,8 @@ class AnalysisDataLink(datalink_base.AnalysisDataLinkBase):
                 filter_args.append((self.model(filter_table).__dict__[column_name]==filter_value, ))
 
         return self._query(query_args=query_args, filter_args=filter_args,
-                           join_args=join_args, select_columns=select_columns)
+                           join_args=join_args, select_columns=select_columns,
+                           fix_wkb=fix_wkb, fix_decimal=fix_decimal, return_sql=return_sql,
+                           import_via_buffer=import_via_buffer)
 
 

--- a/analysisdatalink/datalink_base.py
+++ b/analysisdatalink/datalink_base.py
@@ -1,24 +1,17 @@
 from emannotationschemas import models as em_models, \
     mesh_models as em_mesh_models
-from geoalchemy2.shape import to_shape, from_shape
-from geoalchemy2.elements import WKBElement
-from geoalchemy2.types import Geometry
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql.sqltypes import Boolean
 import time
 import numpy as np
 import pandas as pd
 import os
 import re
 import json
-import shapely
 import contextlib
 import requests
-from multiwrapper import multiprocessing_utils as mu
-from decimal import Decimal
 import analysisdatalink
-from .utils import render_query
+from .utils import render_query, fix_columns_with_query
 
 def build_database_uri(base_uri, dataset_name, materialization_version):
     """Builds database name out of parameters"""
@@ -29,105 +22,6 @@ def build_database_uri(base_uri, dataset_name, materialization_version):
     database_suffix = em_models.format_database_name(dataset_name, materialization_version)
     return base_uri + '/' + database_suffix
 
-# def fix_wkb_columns(df, n_threads=None):
-#     """ Fixes geometry columns """
-#     if len(df) > 0:
-#         for colname in df.columns:
-#             if isinstance(df.at[0,colname], WKBElement):
-#                 xyz = mu.multiprocess_func(wkb_to_numpy, df[colname].tolist(), n_threads=n_threads)
-#                 df[colname] = list(np.array(xyz, dtype=int))
-#     return df
-
-def fix_wkb_column(df_col, wkb_data_start_ind=2, n_threads=None):
-    if len(df_col)==0:
-        return df_col
-
-    if isinstance(df_col.loc[0], str):
-        wkbstr = df_col.loc[0]
-        shp = shapely.wkb.loads(wkbstr[wkb_data_start_ind:], hex=True)
-        if isinstance(shp, shapely.geometry.point.Point):
-            return _fix_wkb_hex_point_column(df_col, n_threads=n_threads)
-    elif isinstance(df_col.loc[0], WKBElement):
-        return _fix_wkb_object_point_column(df_col, n_threads=n_threads)
-
-    return df_col
-
-def _wkb_object_point_to_numpy(wkb):
-    """ Fixes single geometry element """
-    shp = to_shape(wkb)
-    return shp.xy[0][0],shp.xy[1][0], shp.z
-
-def _fix_wkb_object_point_column(df_col, n_threads=None):
-    xyz = mu.multiprocess_func(_wkb_object_point_to_numpy, df_col.tolist(), n_threads=n_threads)
-    return list(np.array(xyz, dtype=int))
-
-def _wkb_hex_point_to_numpy(wkbstr, wkb_data_start_ind=2):
-    shp = shapely.wkb.loads(wkbstr[wkb_data_start_ind:], hex=True)
-    return shp.xy[0][0], shp.xy[1][0], shp.z
-
-def _fix_wkb_hex_point_column(df_col, n_threads=None):
-    xyz = mu.multiprocess_func(_wkb_hex_point_to_numpy,
-                               df_col.tolist(), n_threads)
-    return list(np.array(xyz, dtype=int))
-
-def _fix_boolean_column(df_col):
-    return df_col.apply(lambda x: True if x == 't' else False)
-
-def _fix_decimal_column(df_col):
-    is_integer_col=np.vectorize(lambda x: float(x).is_integer())
-    if np.all(is_integer_col(df_col)):
-        return df_col.apply(int)
-    else:
-        return df_col.apply(np.float)
-
-def fix_columns_with_query(df, query, n_threads=None, fix_decimal=True, fix_wkb=True, wkb_data_start_ind=2):
-    if len(df)>0:
-        schema_model = query.column_descriptions[0]['type']
-        for colname in df.columns:
-            coltype = type(getattr(schema_model, colname).type)
-            
-            if coltype is Boolean:
-                df[colname] = _fix_boolean_column(df[colname])
-
-            elif coltype is Geometry and fix_wkb is True:
-                df[colname] = fix_wkb_column(df[colname], wkb_data_start_ind=wkb_data_start_ind, n_threads=n_threads)
-
-            elif isinstance(df[colname].loc[0], Decimal) and fix_decimal is True:
-                df[colname] = _fix_decimal_column(df[colname])
-            else:
-                continue
-    return df
-
-# def fix_wkb_columns_text(df, n_threads=None, data_start_ind=2):
-#     """Converts wkb columns to point triplets when the columns are already strings.
-    
-#     Parameters
-#     ----------
-#     df : pandas.DataFrame
-#         DataFrame to probe for wkb columns 
-#     """
-#     if len(df) > 0:
-#         for colname in df.columns:
-#             try:
-#                 with open(os.devnull, "w") as f, contextlib.redirect_stderr(f):
-#                     shapely.wkb.loads(df[colname].loc[0][data_start_ind:], hex=True)
-#                 xyz = mu.multiprocess_func(wkb_text_to_numpy, df[colname].tolist(), n_threads)
-#                 df[colname] = list(np.array(xyz, dtype=int))
-#             except:
-#                 continue
-#     return df
-
-# def fix_decimal_columns(df):
-#     if len(df) > 0:
-#         is_decimal = np.vectorize(lambda x: isinstance(x, Decimal))
-#         is_integer_col = np.vectorize(lambda x: float(x).is_integer())
-#         for col in df.columns:
-#             if np.all(is_decimal(df[col])):
-#                 if np.all(is_integer_col(df[col])):
-#                     df[col] = df[col].apply(int)
-#                 else:
-#                     df[col] = df[col].apply(np.float)
-#     return df
 
 def get_materialization_versions(dataset_name, materialization_endpoint=None):
     """ Gets materialization versions with timestamps """

--- a/analysisdatalink/datalink_ext.py
+++ b/analysisdatalink/datalink_ext.py
@@ -15,7 +15,8 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
     def query_synapses(self, synapse_table, pre_ids=None, post_ids=None,
                        compartment_include_filter=None,
                        include_autapses=False,
-                       compartment_table=None):
+                       compartment_table=None, return_sql=False,
+                       fix_wkb=True, fix_decimal=True, import_via_buffer=False):
         """ Query synapses
 
         :param synapse_table: str
@@ -50,13 +51,17 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
 
         df = self.specific_query(tables,
                                  filter_in_dict=filter_in_dict,
-                                 filter_equal_dict=filter_equal_dict)
+                                 filter_equal_dict=filter_equal_dict,
+                                 return_sql=return_sql,
+                                 fix_wkb=fix_wkb, fix_decimal=fix_decimal,
+                                 import_via_buffer=import_via_buffer)
 
         return df
 
     def query_cell_types(self, cell_type_table, cell_type_include_filter=None,
                          cell_type_exclude_filter=None, return_only_ids=False,
-                         exclude_zero_root_ids=False):
+                         exclude_zero_root_ids=False, fix_wkb=True, fix_decimal=True,
+                         return_sql=False, import_via_buffer=False):
         """ Query cell type tables
 
         :param cell_type_table: str
@@ -87,7 +92,11 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
         df = self.specific_query(tables=[cell_type_table],
                                  filter_in_dict=filter_in_dict,
                                  filter_notin_dict=filter_notin_dict,
-                                 select_columns=select_columns)
+                                 select_columns=select_columns,
+                                 fix_wkb=fix_wkb,
+                                 fix_decimal=fix_decimal,
+                                 return_sql=return_sql,
+                                 import_via_buffer=import_via_buffer)
 
         if return_only_ids:
             return np.array(df, dtype = np.uint64).squeeze()
@@ -96,7 +105,8 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
 
     def query_cell_ids(self, cell_id_table, cell_id_filter=None,
                        cell_id_exclude_filter=None, return_only_ids=False,
-                       exclude_zero_root_ids=False):
+                       exclude_zero_root_ids=False, fix_wkb=True, fix_decimal=True,
+                       return_sql=False, import_via_buffer=False):
         """ Query cell ids
 
         :param cell_id_table: str
@@ -125,7 +135,11 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
         df = self.specific_query(tables=[cell_id_table],
                                  filter_in_dict=filter_in_dict,
                                  filter_notin_dict=filter_notin_dict,
-                                 select_columns=select_columns)
+                                 select_columns=select_columns,
+                                 fix_wkb=fix_wkb,
+                                 fix_decimal=fix_decimal,
+                                 return_sql=return_sql,
+                                 import_via_buffer=import_via_buffer)
 
         if return_only_ids:
             return np.array(df, dtype=np.uint64).squeeze()
@@ -134,7 +148,9 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
 
     def query_coreg(self, coreg_table, cell_id_filter=None,
                     cell_id_exclude_filter=None, return_only_mapping=False,
-                    exclude_zero_root_ids=False):
+                    exclude_zero_root_ids=False,
+                    fix_wkb=True, fix_decimal=True,
+                    return_sql=False, import_via_buffer=False):
         """ Queries coregistration
 
         :param coreg_table: str
@@ -165,7 +181,11 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
         df = self.specific_query(tables=[coreg_table],
                                  filter_in_dict=filter_in_dict,
                                  filter_notin_dict=filter_notin_dict,
-                                 select_columns=select_columns)
+                                 select_columns=select_columns,
+                                 fix_wkb=fix_wkb,
+                                 fix_decimal=fix_decimal,
+                                 return_sql=return_sql,
+                                 import_via_buffer=import_via_buffer)
 
         if return_only_mapping:
             return np.array(df, dtype=np.uint64).squeeze()

--- a/analysisdatalink/datalink_ext.py
+++ b/analysisdatalink/datalink_ext.py
@@ -16,7 +16,8 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                        compartment_include_filter=None,
                        include_autapses=False,
                        compartment_table=None, return_sql=False,
-                       fix_wkb=True, fix_decimal=True, import_via_buffer=False):
+                       fix_wkb=True, fix_decimal=True, import_via_buffer=False,
+                       n_threads=None):
         """ Query synapses
 
         :param synapse_table: str
@@ -54,14 +55,15 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                                  filter_equal_dict=filter_equal_dict,
                                  return_sql=return_sql,
                                  fix_wkb=fix_wkb, fix_decimal=fix_decimal,
-                                 import_via_buffer=import_via_buffer)
+                                 import_via_buffer=import_via_buffer,
+                                 n_threads=n_threads)
 
         return df
 
     def query_cell_types(self, cell_type_table, cell_type_include_filter=None,
                          cell_type_exclude_filter=None, return_only_ids=False,
                          exclude_zero_root_ids=False, fix_wkb=True, fix_decimal=True,
-                         return_sql=False, import_via_buffer=False):
+                         return_sql=False, import_via_buffer=False, n_threads=None):
         """ Query cell type tables
 
         :param cell_type_table: str
@@ -96,7 +98,8 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                                  fix_wkb=fix_wkb,
                                  fix_decimal=fix_decimal,
                                  return_sql=return_sql,
-                                 import_via_buffer=import_via_buffer)
+                                 import_via_buffer=import_via_buffer,
+                                 n_threads=n_threads)
 
         if return_only_ids:
             return np.array(df, dtype = np.uint64).squeeze()
@@ -106,7 +109,7 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
     def query_cell_ids(self, cell_id_table, cell_id_filter=None,
                        cell_id_exclude_filter=None, return_only_ids=False,
                        exclude_zero_root_ids=False, fix_wkb=True, fix_decimal=True,
-                       return_sql=False, import_via_buffer=False):
+                       return_sql=False, import_via_buffer=False, n_threads=None):
         """ Query cell ids
 
         :param cell_id_table: str
@@ -139,7 +142,7 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                                  fix_wkb=fix_wkb,
                                  fix_decimal=fix_decimal,
                                  return_sql=return_sql,
-                                 import_via_buffer=import_via_buffer)
+                                 import_via_buffer=import_via_buffer, n_threads=n_threads)
 
         if return_only_ids:
             return np.array(df, dtype=np.uint64).squeeze()
@@ -150,7 +153,7 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                     cell_id_exclude_filter=None, return_only_mapping=False,
                     exclude_zero_root_ids=False,
                     fix_wkb=True, fix_decimal=True,
-                    return_sql=False, import_via_buffer=False):
+                    return_sql=False, import_via_buffer=False, n_threads=None):
         """ Queries coregistration
 
         :param coreg_table: str
@@ -185,7 +188,7 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                                  fix_wkb=fix_wkb,
                                  fix_decimal=fix_decimal,
                                  return_sql=return_sql,
-                                 import_via_buffer=import_via_buffer)
+                                 import_via_buffer=import_via_buffer, n_threads=n_threads)
 
         if return_only_mapping:
             return np.array(df, dtype=np.uint64).squeeze()

--- a/analysisdatalink/datalink_ext.py
+++ b/analysisdatalink/datalink_ext.py
@@ -16,23 +16,47 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                        compartment_include_filter=None,
                        include_autapses=False,
                        compartment_table=None, return_sql=False,
-                       fix_wkb=True, fix_decimal=True, import_via_buffer=False,
+                       fix_wkb=True, fix_decimal=True, import_via_buffer=True,
                        n_threads=None):
-        """ Query synapses
-
-        :param synapse_table: str
-            table name without dataset prefix or version suffix
-        :param pre_ids: None, list or np.ndarray
-        :param post_ids: None, list or np.ndarray
-        :param compartment_table: None, str
-            defines compartment table -- has to be 'postsynapsecompartment'
-        :param compartment_include_filter: list of str
-        :param include_autapses: bool
-        :param compartment_table: None, str
-            DO NOT USE at the moment since there are no good compartment
-            labels yet
-        :return:
+        """Query a synapse table and return a dataframe
+        
+        Parameters
+        ----------
+        synapse_table : str
+            Table name with a synapse schema
+        pre_ids : collection of ints, optional
+            Object ids for presynaptic neurons, by default None
+        post_ids : collection of ints, optional
+            Object ids for postsynaptic neurons, by default None
+        compartment_include_filter : None, optional
+            Not currently implemented. By default None
+        include_autapses : bool, optional
+            Include synapses whose pre- and post-synaptic objects are the same, by default False
+        compartment_table : str, optional
+            Not currently implemented. Would be a table name for synapse compartments. By default None
+        return_sql : bool, optional
+            Return the sqlalchemy query object instead of the data itself, by default False
+        fix_wkb : bool, optional
+            Convert wkb-formatted spatial location columns to numpy 3-vectors. Setting to False
+            can be much faster, but spatial information is not easy to parse. These columns can be
+            parsed after the fact with analysisdatalink.fix_wkb_column. Optional, by default True
+        fix_decimal : bool, optional
+            Convert Decimal columns to ints. Not used if import_via_buffer is True. By default True
+        import_via_buffer : bool, optional
+            Flag to determine whether to use a fast csv and tempfile based SQL import (if True) or the pandas
+            native read_sql import (if False). If column formatting is odd, try setting to False. Optional, by default True.
+        n_threads : int or None, optional
+            Number of threads to use when parsing columns to convert wkb. Unused if fix_wkb is False. If set to 1,
+            multiprocessing is not used and slower numpy vectorization is used instead.
+            If None, uses the number of cpus available on the device. By default None
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame representation of the query results.
         """
+        
+        
 
         filter_in_dict = defaultdict(dict)
         filter_equal_dict = defaultdict(dict)
@@ -63,16 +87,41 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
     def query_cell_types(self, cell_type_table, cell_type_include_filter=None,
                          cell_type_exclude_filter=None, return_only_ids=False,
                          exclude_zero_root_ids=False, fix_wkb=True, fix_decimal=True,
-                         return_sql=False, import_via_buffer=False, n_threads=None):
-        """ Query cell type tables
-
-        :param cell_type_table: str
-            table name without dataset prefix or version suffix
-        :param cell_type_include_filter: list of str
-        :param cell_type_exclude_filter: list of str
-        :param return_only_ids: bool
-        :param exclude_zero_root_ids: bool
-        :return: pandas DataFrame or numpy array
+                         return_sql=False, import_via_buffer=True, n_threads=None):
+        """Query a synapse table and return a dataframe
+        
+        Parameters
+        ----------
+        cell_type_table : str
+            Table name with a cell_type schema
+        cell_type_include_filter : collection of str, optional
+            Cell types to include
+        cell_type_exclude_filter : collection of str, optional
+            Cell types to exclude 
+        return_only_ids : bool, optional
+            Process to include only root ids matching the query.
+        exclude_zero_root_ids : bool, optional
+            Fitler out points with a null segmentation id. 
+        return_sql : bool, optional
+            Return the sqlalchemy query object instead of the data itself, by default False
+        fix_wkb : bool, optional
+            Convert wkb-formatted spatial location columns to numpy 3-vectors. Setting to False
+            can be much faster, but spatial information is not easy to parse. These columns can be
+            parsed after the fact with analysisdatalink.fix_wkb_column. Optional, by default True
+        fix_decimal : bool, optional
+            Convert Decimal columns to ints. Not used if import_via_buffer is True. By default True
+        import_via_buffer : bool, optional
+            Flag to determine whether to use a fast csv and tempfile based SQL import (if True) or the pandas
+            native read_sql import (if False). If column formatting is odd, try setting to False. Optional, by default True.
+        n_threads : int or None, optional
+            Number of threads to use when parsing columns to convert wkb. Unused if fix_wkb is False. If set to 1,
+            multiprocessing is not used and slower numpy vectorization is used instead.
+            If None, uses the number of cpus available on the device. By default None
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame representation of the query results.
         """
 
         filter_in_dict = defaultdict(dict)
@@ -109,16 +158,42 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
     def query_cell_ids(self, cell_id_table, cell_id_filter=None,
                        cell_id_exclude_filter=None, return_only_ids=False,
                        exclude_zero_root_ids=False, fix_wkb=True, fix_decimal=True,
-                       return_sql=False, import_via_buffer=False, n_threads=None):
-        """ Query cell ids
+                       return_sql=False, import_via_buffer=True, n_threads=None):
 
-        :param cell_id_table: str
-            table name without dataset prefix or version suffix
-        :param cell_id_filter: list of uint64s
-        :param cell_id_exclude_filter: list of uint64s
-        :param return_only_ids: bool
-        :param exclude_zero_root_ids:bool
-        :return: pandas DataFrame or numpy array
+        """ Query cell id tables
+        
+        Parameters
+        ----------
+        cell_id_table : str
+            Table name for a microns_functional_coregistration table
+        cell_id_filter : list of uint64s, optional
+            List of root ids to include. Default is None.
+        cell_id_exclude_filter : list of uint64s, optional
+            List of root ids to exclude. Default is None.
+        return_only_ids : bool, optional
+            Process to include only root ids matching the query. Default is False.
+        exclude_zero_root_ids : bool, optional
+            Fitler out points with a null segmentation id. Default is False.
+        return_sql : bool, optional
+            Return the sqlalchemy query object instead of the data itself, by default False
+        fix_wkb : bool, optional
+            Convert wkb-formatted spatial location columns to numpy 3-vectors. Setting to False
+            can be much faster, but spatial information is not easy to parse. These columns can be
+            parsed after the fact with analysisdatalink.fix_wkb_column. Optional, by default True
+        fix_decimal : bool, optional
+            Convert Decimal columns to ints. Not used if import_via_buffer is True. By default True
+        import_via_buffer : bool, optional
+            Flag to determine whether to use a fast csv and tempfile based SQL import (if True) or the pandas
+            native read_sql import (if False). If column formatting is odd, try setting to False. Optional, by default True.
+        n_threads : int or None, optional
+            Number of threads to use when parsing columns to convert wkb. Unused if fix_wkb is False. If set to 1,
+            multiprocessing is not used and slower numpy vectorization is used instead.
+            If None, uses the number of cpus available on the device. By default None
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame representation of the query results.
         """
         filter_in_dict = defaultdict(dict)
         if cell_id_filter is not None:
@@ -153,18 +228,41 @@ class AnalysisDataLinkExt(datalink.AnalysisDataLink):
                     cell_id_exclude_filter=None, return_only_mapping=False,
                     exclude_zero_root_ids=False,
                     fix_wkb=True, fix_decimal=True,
-                    return_sql=False, import_via_buffer=False, n_threads=None):
-        """ Queries coregistration
-
-        :param coreg_table: str
-            table name without dataset prefix or version suffix
-        :param cell_id_filter: list of uint64s
-        :param cell_id_exclude_filter: list of uint64s
-        :param return_only_mapping: bool
-            returns an array of [[root_id, f_id], ...]
-        :param exclude_zero_root_ids: bool
-            exclude zero root ids
-        :return: pandas DataFrame or numpy array
+                    return_sql=False, import_via_buffer=True, n_threads=None):
+        """ Query cell id tables
+        
+        Parameters
+        ----------
+        coreg_table : str
+            Table name for a microns_functional_coregistration table
+        cell_id_filter : list of uint64s, optional
+            List of root ids to include. Default is None.
+        cell_id_exclude_filter : list of uint64s, optional
+            List of root ids to exclude. Default is None.
+        return_only_ids : bool, optional
+            Process to include only root ids matching the query. Default is False.
+        exclude_zero_root_ids : bool, optional
+            Fitler out points with a null segmentation id. Default is False.
+        return_sql : bool, optional
+            Return the sqlalchemy query object instead of the data itself, by default False
+        fix_wkb : bool, optional
+            Convert wkb-formatted spatial location columns to numpy 3-vectors. Setting to False
+            can be much faster, but spatial information is not easy to parse. These columns can be
+            parsed after the fact with analysisdatalink.fix_wkb_column. Optional, by default True
+        fix_decimal : bool, optional
+            Convert Decimal columns to ints. Not used if import_via_buffer is True. By default True
+        import_via_buffer : bool, optional
+            Flag to determine whether to use a fast csv and tempfile based SQL import (if True) or the pandas
+            native read_sql import (if False). If column formatting is odd, try setting to False. Optional, by default True.
+        n_threads : int or None, optional
+            Number of threads to use when parsing columns to convert wkb. Unused if fix_wkb is False. If set to 1,
+            multiprocessing is not used and slower numpy vectorization is used instead.
+            If None, uses the number of cpus available on the device. By default None
+        
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame representation of the query results.
         """
         filter_in_dict = defaultdict(dict)
         if cell_id_filter is not None:

--- a/analysisdatalink/utils.py
+++ b/analysisdatalink/utils.py
@@ -1,0 +1,42 @@
+from sqlalchemy.orm import Query
+from datetime import date, timedelta
+from datetime import datetime
+
+basestring = str
+
+def render_query(statement, dialect=None):
+    """
+    Based on https://stackoverflow.com/questions/5631078/sqlalchemy-print-the-actual-query#comment39255415_23835766
+    Generate an SQL expression string with bound parameters rendered inline
+    for the given SQLAlchemy statement.
+    """
+    if isinstance(statement, Query):
+        if dialect is None:
+            dialect = statement.session.bind.dialect
+        statement = statement.statement
+    elif dialect is None:
+        dialect = statement.bind.dialect
+
+    class LiteralCompiler(dialect.statement_compiler):
+
+        def visit_bindparam(self, bindparam, within_columns_clause=False,
+                            literal_binds=False, **kwargs):
+            return self.render_literal_value(bindparam.value, bindparam.type)
+
+        def render_array_value(self, val, item_type):
+            if isinstance(val, list):
+                return "{%s}" % ",".join([self.render_array_value(x, item_type) for x in val])
+            return self.render_literal_value(val, item_type)
+
+        def render_literal_value(self, value, type_):
+            if isinstance(value, int):
+                return str(value)
+            if isinstance(value, bool):
+                return bool(value)
+            elif isinstance(value, (basestring, date, datetime, timedelta)):
+                return "'%s'" % str(value).replace("'", "''")
+            elif isinstance(value, list):
+                return "'{%s}'" % (",".join([self.render_array_value(x, type_.item_type) for x in value]))
+            return super(LiteralCompiler, self).render_literal_value(value, type_)
+
+    return LiteralCompiler(dialect, statement).process(statement)

--- a/analysisdatalink/utils.py
+++ b/analysisdatalink/utils.py
@@ -1,8 +1,117 @@
 from sqlalchemy.orm import Query
+from geoalchemy2.elements import WKBElement
+from geoalchemy2.types import Geometry
+from sqlalchemy.sql.sqltypes import Boolean
+from decimal import Decimal
+from multiwrapper import multiprocessing_utils as mu
+import numpy as np
+from geoalchemy2.shape import to_shape
 from datetime import date, timedelta
 from datetime import datetime
+from functools import partial
+import shapely
 
-basestring = str
+
+def fix_wkb_column(df_col, wkb_data_start_ind=2, n_threads=None):
+    """Convert a column with 3-d point data stored as in WKB format
+    to list of arrays of integer point locations. The series can not be
+    mixed.
+    
+    Parameters
+    ----------
+    df_col : pandas.Series
+        N-length Series (representing a column of a dataframe) to convert. All elements
+        should be either a hex-string or a geoalchemy2 WKBElement object.
+    wkb_data_start_ind : int, optional
+        When the WKB data is represented as a hex string, sets the first character
+        of the actual data. By default 2, since the current implementation has
+        a prefix when the data is imported as text. Set to 0 if the data is just
+        an exact hex string already. This value is ignored if the series data is in
+        WKBElement object form.
+    n_threads : int or None, optional
+        Sets number of threads. If None, uses as many threads as CPUs.
+        If n_threads is set to 1, multiprocessing is not used.
+        Optional, by default None.
+    
+    Returns
+    -------
+    list
+        N-length list of arrays of 3d points
+    """
+
+    if len(df_col) == 0:
+        return df_col.tolist()
+
+    if isinstance(df_col.loc[0], str):
+        wkbstr = df_col.loc[0]
+        shp = shapely.wkb.loads(wkbstr[wkb_data_start_ind:], hex=True)
+        if isinstance(shp, shapely.geometry.point.Point):
+            return _fix_wkb_hex_point_column(df_col, n_threads=n_threads)
+    elif isinstance(df_col.loc[0], WKBElement):
+        return _fix_wkb_object_point_column(df_col, n_threads=n_threads)
+    return df_col.tolist()
+
+
+def fix_columns_with_query(df, query, n_threads=None, fix_decimal=True, fix_wkb=True, wkb_data_start_ind=2):
+    """ Use a query object to suggest how to convert columns imported from csv to correct types.
+    """
+    if len(df) > 0:
+        schema_model = query.column_descriptions[0]['type']
+        for colname in df.columns:
+            coltype = type(getattr(schema_model, colname).type)
+
+            if coltype is Boolean:
+                df[colname] = _fix_boolean_column(df[colname])
+
+            elif coltype is Geometry and fix_wkb is True:
+                df[colname] = fix_wkb_column(
+                    df[colname], wkb_data_start_ind=wkb_data_start_ind, n_threads=n_threads)
+
+            elif isinstance(df[colname].loc[0], Decimal) and fix_decimal is True:
+                df[colname] = _fix_decimal_column(df[colname])
+            else:
+                continue
+    return df
+
+
+def _wkb_object_point_to_numpy(wkb):
+    """ Fixes single geometry element """
+    shp = to_shape(wkb)
+    return shp.xy[0][0], shp.xy[1][0], shp.z
+
+
+def _fix_wkb_object_point_column(df_col, n_threads=None):
+    if n_threads != 1:
+        xyz = mu.multiprocess_func(_wkb_object_point_to_numpy, df_col.tolist(), n_threads=n_threads)
+    else:
+        func = np.vectorize(_wkb_object_point_to_numpy)
+        xyz = np.vstack(func(df_col.values)).T
+    return list(np.array(xyz, dtype=int))
+
+def _wkb_hex_point_to_numpy(wkbstr, wkb_data_start_ind=2):
+    shp = shapely.wkb.loads(wkbstr[wkb_data_start_ind:], hex=True)
+    return shp.xy[0][0], shp.xy[1][0], shp.z
+
+def _fix_wkb_hex_point_column(df_col, wkb_data_start_ind=2, n_threads=None):
+    func = partial(_wkb_hex_point_to_numpy, wkb_data_start_ind=wkb_data_start_ind)
+    if n_threads != 1:
+        xyz = mu.multiprocess_func(func, df_col.tolist(), n_threads)
+    else:
+        func = np.vectorize(func)
+        xyz = np.vstack(func(df_col.values)).T
+    return list(np.array(xyz, dtype=int))
+
+
+def _fix_boolean_column(df_col):
+    return df_col.apply(lambda x: True if x == 't' else False)
+
+
+def _fix_decimal_column(df_col):
+    is_integer_col = np.vectorize(lambda x: float(x).is_integer())
+    if np.all(is_integer_col(df_col)):
+        return df_col.apply(int)
+    else:
+        return df_col.apply(np.float)
 
 def render_query(statement, dialect=None):
     """
@@ -33,7 +142,7 @@ def render_query(statement, dialect=None):
                 return str(value)
             if isinstance(value, bool):
                 return bool(value)
-            elif isinstance(value, (basestring, date, datetime, timedelta)):
+            elif isinstance(value, (str, date, datetime, timedelta)):
                 return "'%s'" % str(value).replace("'", "''")
             elif isinstance(value, list):
                 return "'{%s}'" % (",".join([self.render_array_value(x, type_.item_type) for x in value]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ sqlalchemy
 pandas
 requests
 numpy
+multiwrapper
+


### PR DESCRIPTION
Add optional (but default) import option that processes sql data into tables much faster, via csv temple. Also, optionally (but default) convert WKB columns with multiprocessing and expose the option to skip.